### PR TITLE
Fix an encoding-caused name error.

### DIFF
--- a/doc/pi_zip.cnx
+++ b/doc/pi_zip.cnx
@@ -110,7 +110,7 @@ Copyright: Copyright (C) 2005-2015 Charles E Campbell *zip-copyright*
 		    * (Ben Staniford) now uses
 			has("win32unix") && executable("cygpath")
 		      before converting to cygwin-style paths
-   v24 Jun 21, 2010 * (CÃ©dric Bosdonnat) unzip seems to need its filenames
+   v24 Jun 21, 2010 * (Cédric Bosdonnat) unzip seems to need its filenames
 		      fnameescape'd as well as shellquote'd
 		    * (Motoya Kurotsu) inserted keepj before 0d to protect
 		      jump list


### PR DESCRIPTION
The name ‘Cédric’ was wrong, probably caused by treating a UTF-8 sequence as Latin-1.